### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/badrigautam19/7bebbbb4-2927-423c-8860-c2a95efc942d/3dda390a-5bc9-46b8-84aa-a9ba824e4f23/_apis/work/boardbadge/7f699a34-70ef-4d80-ac25-b92e968d6e95)](https://dev.azure.com/badrigautam19/7bebbbb4-2927-423c-8860-c2a95efc942d/_boards/board/t/3dda390a-5bc9-46b8-84aa-a9ba824e4f23/Microsoft.RequirementCategory)
 #XYZ Company
 
 Simple website for the company having some department.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/badrigautam19/7bebbbb4-2927-423c-8860-c2a95efc942d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.